### PR TITLE
[ios] [ui] Add TextInput placeholder prop

### DIFF
--- a/packages/expo-ui/src/swift-ui/TextInput/index.tsx
+++ b/packages/expo-ui/src/swift-ui/TextInput/index.tsx
@@ -21,7 +21,7 @@ export type TextInputProps = {
   /**
    * The string that will be rendered before text input has been entered.
    */
-  placeholder?: boolean;
+  placeholder?: string;
   /**
    * If true, the text input can be multiple lines.
    * While the content will wrap, there's no keyboard button to insert a new line.

--- a/packages/expo-ui/src/swift-ui/TextInput/index.tsx
+++ b/packages/expo-ui/src/swift-ui/TextInput/index.tsx
@@ -19,6 +19,10 @@ export type TextInputProps = {
    */
   onChangeText: (value: string) => void;
   /**
+   * The string that will be rendered before text input has been entered.
+   */
+  placeholder?: boolean;
+  /**
    * If true, the text input can be multiple lines.
    * While the content will wrap, there's no keyboard button to insert a new line.
    */


### PR DESCRIPTION
# Why

types are missing `placeholder` but its already a valid prop in the swift view.

https://github.com/expo/expo/blob/sdk-53/packages/expo-ui/ios/TextInput/TextInputView.swift#L6
https://github.com/expo/expo/blob/sdk-53/packages/expo-ui/ios/TextInput/TextInputView.swift#L64

# How

Tested on a local app running expo-53 with swift ui


# Test Plan
![Screenshot 2025-05-02 at 10 59 04 PM](https://github.com/user-attachments/assets/489229ca-ed28-4cbe-a33f-b97a0ab7f092)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
